### PR TITLE
Major RT Engine Fix 

### DIFF
--- a/pylayers/antprop/interactions.py
+++ b/pylayers/antprop/interactions.py
@@ -699,6 +699,7 @@ class IntR(Inter):
         if np.shape(self.data)[0]!=len(self.idx):
             self.data=self.data.T
 
+
         if len(self.data) != 0:
             mapp = []
             # loop on all type of materials used for reflexion
@@ -719,8 +720,8 @@ class IntR(Inter):
             self.A[:, np.array((mapp)), :, :] = R
             self.alpha = np.array(self.alpha*len(self.idx), dtype=complex)
             self.gamma = np.array(self.gamma*len(self.idx), dtype=complex)
-
             return(self.A)
+
         else:
             self.A = self.data[:, None, None, None]
             # print 'no R interaction to evaluate'

--- a/pylayers/antprop/rays.py
+++ b/pylayers/antprop/rays.py
@@ -2015,15 +2015,14 @@ class Rays(PyLayers,dict):
                 # dimension i and r are merged
                 b  = self[k]['B'][:,:,1:,:].reshape(2, 2, size2-nbray,order='F')
 
+
                 ## find used slab
                 ##################
                 # find slab type for the rnstr
                 # nstrf is a number of slab
                 # this is a problem for handling subsegment
                 #
-
-                sl = L.sla[nstrf]
-
+                
                 # seek for interactions position
                 ################################
 
@@ -2036,19 +2035,22 @@ class Rays(PyLayers,dict):
                 # assign floor and ceil slab
                 ############################
 
+
+                slT=L.sla[nstrf[uT]]
+                slR=L.sla[nstrf[uR]]
                 # WARNING
                 # in future version floor and ceil could be different for each cycle.
                 # this information would be directly obtained from L.Gs
                 # then the two following lines would have to be  modified
+                slRf=np.array(['FLOOR']*len(uRf))
+                slRc=np.array(['CEIL']*len(uRc))
 
-                sl[uRf] = 'FLOOR'
-                sl[uRc] = 'CEIL'
 
                 # Fill the used slab
                 #####################
 
-                tsl = np.hstack((tsl, sl[uT]))
-                rsl = np.hstack((rsl, sl[uR], sl[uRf], sl[uRc]))
+                tsl = np.hstack((tsl, slT))
+                rsl = np.hstack((rsl, slR, slRf, slRc))
                 if self[k].has_key('diffvect'): 
                     dw = np.hstack((dw,self[k]['diffslabs'])) 
     ##            for s in uslv:

--- a/pylayers/gis/layout.py
+++ b/pylayers/gis/layout.py
@@ -481,7 +481,11 @@ class Layout(PyLayers):
             st = st + "sla : list of all slab names (Nsmax+Nss+1)" +"\n"
         if hasattr(self,'degree'):
             st = st + "degree : degree of nodes " +"\n"
-
+        st = st + "\nUseful tip" + "\n----------------\n"
+        st = st + "Point p in Gs => p_coord:\n"
+        st = st + "p -> u = self.iupnt[p] -> p_coord = self.pt[:,u]\n\n"
+        st = st + "Segment s in Gs => s_ab coordinates \n"
+        st = st + "s -> u = self.tgs[s] -> v = self.tahe[:,u] -> s_ab = self.pt[:,v]\n\n"
         return(st)
 
     def __add__(self, other):
@@ -998,7 +1002,8 @@ class Layout(PyLayers):
             #self.stridess = np.array(np.zeros(nsmax+1),dtype=int)
             self.stridess = np.empty(nsmax+1,dtype=int)
             # +1 is for discarding index 0 (unused here)
-            self.sla  = np.empty((nsmax+1+self.Nss), dtype='S20')
+            # self.sla  = np.empty((nsmax+1+self.Nss), dtype='S20')
+            self.sla  = np.zeros((nsmax+1+self.Nss), dtype='S20')
             self.offset = np.empty(nsmax+1+self.Nss,dtype=int)
 
 


### PR DESCRIPTION
This pull request addresses an important issue in the RT engine.

In some function, the **association** between **Gs nodes** (segments and/or points ) and their **coordinates** was **not always correct**.

The impacted function was :

+ Signature.image2
+ Signature.backtrace
+ Rays.fillinter

Results on defstr are coherent but **this PR must be tested before accepted**