### PR TITLE
Fix errors for "setup.py install".

### DIFF
--- a/pylayers/em/openems/probebox.py
+++ b/pylayers/em/openems/probebox.py
@@ -4,8 +4,8 @@ from xml.etree.ElementTree import Element
 from xml.etree import ElementTree
 
 class ProbeBox(Element):
-	def __init__(self, Name='port_ut1', Type='wv', Weight='1'):
-"""
+    def __init__(self, Name='port_ut1', Type='wv', Weight='1'):
+        """
 
 type:     0 for voltage probing => 'vp'
           1 for current probing => 'cp'
@@ -15,24 +15,24 @@ type:     0 for voltage probing => 'vp'
          11 for waveguide current mode matching => 'wc'
 
 """
-	Element.__init__(self,'ProbeBox')
-	self.attrib['Weight']=Weight
-	if Type=='vp'
-		self.attrib['Type']='0'
-	if Type=='cp'
-		self.attrib['Type']='1'
-	if Type=='Efp'
-		self.attrib['Type']='2'
-	if Type=='Hfp'
-		self.attrib['Type']='3'
-	if Type=='wv'
-		self.attrib['Type']='10'
-	if Type=='wc'
-		self.attrib['Type']='11'
-    self.append(Attributes('Attributes',a))
+        Element.__init__(self,'ProbeBox')
+        self.attrib['Weight']=Weight
+        if Type=='vp':
+            self.attrib['Type']='0'
+        if Type=='cp':
+            self.attrib['Type']='1'
+        if Type=='Efp':
+            self.attrib['Type']='2'
+        if Type=='Hfp':
+            self.attrib['Type']='3'
+        if Type=='wv':
+            self.attrib['Type']='10'
+        if Type=='wc':
+            self.attrib['Type']='11'
+        self.append(Attributes('Attributes',a))
 
 
 
 class Attributes(Element):
-	def __init__(self, name, a):
-	Element.__init__(self, name, ModeFunctionX=str(a[0]), ModeFunctionY=str(a[1]), ModeFunctionZ=str(a[2]))
+    def __init__(self, name, a):
+        Element.__init__(self, name, ModeFunctionX=str(a[0]), ModeFunctionY=str(a[1]), ModeFunctionZ=str(a[2]))

--- a/pylayers/gis/lireifc.py
+++ b/pylayers/gis/lireifc.py
@@ -68,7 +68,7 @@ for li in lig:
         if v.find('IFCDIRECTION')!=-1:
             spt  = v.split('DIRECTION')[1]
             sspt = spt.replace('(','').replace(')','').split(',')
-            print sspt
+            print(sspt)
             if len(sspt)==3:
                 vec  = np.array([float(sspt[0]),float(sspt[1]),float(sspt[2])])
             else:

--- a/pylayers/location/algebraic/test.py
+++ b/pylayers/location/algebraic/test.py
@@ -1,4 +1,4 @@
-# -*- coding:Utf-8 -*-
+# -*- coding:utf-8 -*-
 #####################################################################
 #This file is part of RGPA.
 
@@ -114,7 +114,7 @@ if __name__=="__main__":
     MS = np.vstack((MS,MS2))
     MS = np.vstack((MS,MS3))
     MS = np.vstack((MS,MS4))
-     MS = np.delete(MS,0,0)
+    MS = np.delete(MS,0,0)
 
 
 

--- a/pylayers/signal/beamforming.py
+++ b/pylayers/signal/beamforming.py
@@ -5,12 +5,12 @@ import scipy as sp
 
 def weight(N,**kwags):
     default = {'sll':20,
-               'typ','uniform'
+               'typ':'uniform'
               }
 
     for k in defaults:
-        fi k not in kwargs:
-            kwargs[k]=defaluts[k]
+        if k not in kwargs:
+            kwargs[k]=defaults[k]
 
     if typ=='uniform':
         pass

--- a/pylayers/signal/beamforming.py
+++ b/pylayers/signal/beamforming.py
@@ -3,10 +3,10 @@ import numpy as np
 import scipy as sp
 
 
-def weight(N,**kwags):
-    default = {'sll':20,
-               'typ':'uniform'
-              }
+def weight(N,**kwargs):
+    defaults = {'sll':20,
+                'typ':'uniform'
+               }
 
     for k in defaults:
         if k not in kwargs:


### PR DESCRIPTION
When running `setup.py install` in Ubuntu 16.04, the following errors appeared.  This PR fixes those errors.  Note that the issue with `print sspt` is due to `from __future__ import print_function` in that file. `probebox.py` had several more errors after fixing the initial indentation error.

```
byte-compiling build/bdist.linux-x86_64/egg/pylayers/em/openems/probebox.py to probebox.pyc
Sorry: IndentationError: expected an indented block (probebox.py, line 8)
byte-compiling build/bdist.linux-x86_64/egg/pylayers/gis/lireifc.py to lireifc.pyc
  File "build/bdist.linux-x86_64/egg/pylayers/gis/lireifc.py", line 71
    print sspt
             ^
SyntaxError: invalid syntax
byte-compiling build/bdist.linux-x86_64/egg/pylayers/location/algebraic/test.py to test.pyc
Sorry: IndentationError: unexpected indent (test.py, line 117)
byte-compiling build/bdist.linux-x86_64/egg/pylayers/signal/beamforming.py to beamforming.pyc
  File "build/bdist.linux-x86_64/egg/pylayers/signal/beamforming.py", line 8
    'typ','uniform'
         ^
SyntaxError: invalid syntax
```