### PR TITLE
fixing error message during python setup.py install

### DIFF
--- a/pylayers/location/geometric/Scenario_base.py
+++ b/pylayers/location/geometric/Scenario_base.py
@@ -547,7 +547,7 @@ class Scenario(object):
 
                 if self.parmsc['save_pe']:
                     self.p_LS.append(p_LS)
-                if self.parmsc['Constrain_Type'] != 'hybrid'
+                if self.parmsc['Constrain_Type'] != 'hybrid':
                     errLS   = np.sqrt(np.dot(p_LS[:2]-pbn[:2],p_LS[:2]-pbn[:2])) 
 
                 #elif self.parmsc['Algebraic_method'] == 'CRB':


### PR DESCRIPTION
This PR fixes the following installation error message (trace: install anaconda, create environment and activate, run install_linux):
"
byte-compiling build/bdist.linux-x86_64/egg/pylayers/location/geometric/Scenario_base.py to Scenario_base.pyc
  File "build/bdist.linux-x86_64/egg/pylayers/location/geometric/Scenario_base.py", line 550
    if self.parmsc['Constrain_Type'] != 'hybrid'
                                               ^
SyntaxError: invalid syntax
"
-> just add a ':' at the end of the highlighted line.